### PR TITLE
Add .git folder to .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
+.git
 dist
 node_modules
 db-data


### PR DESCRIPTION
I don't think we need `.git` folder inside our images.
What do you think?