### PR TITLE
remove dismissDefaultMessages

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -53,7 +53,6 @@ async function bootstrap() {
         new ValidationPipe({
             whitelist: true,
             transform: true,
-            dismissDefaultMessages: true,
             validationError: {
                 target: false,
             },


### PR DESCRIPTION
I removed `dismissDefaultMessages` so `class-validator` can display error messages when validating DTOs