### PR TITLE
fix: translation service provider declaration in shared module

### DIFF
--- a/src/shared/shared.module.ts
+++ b/src/shared/shared.module.ts
@@ -4,6 +4,7 @@ import { JwtModule } from '@nestjs/jwt';
 import { AwsS3Service } from './services/aws-s3.service';
 import { ConfigService } from './services/config.service';
 import { GeneratorService } from './services/generator.service';
+import { TranslationService } from './services/translation.service';
 import { ValidatorService } from './services/validator.service';
 
 const providers = [
@@ -11,6 +12,7 @@ const providers = [
     ValidatorService,
     AwsS3Service,
     GeneratorService,
+    TranslationService,
 ];
 
 @Global()


### PR DESCRIPTION
It's just a little matter. TranslationService was not declared as a provider and an error was launched in UserCotroller because of it.