### PR TITLE
Fix Interceptors for file when isArray

### DIFF
--- a/src/decorators/swagger.schema.ts
+++ b/src/decorators/swagger.schema.ts
@@ -6,7 +6,7 @@ import {
   ROUTE_ARGS_METADATA,
 } from '@nestjs/common/constants';
 import { RouteParamtypes } from '@nestjs/common/enums/route-paramtypes.enum';
-import { FileInterceptor } from '@nestjs/platform-express';
+import { FileInterceptor, FilesInterceptor } from '@nestjs/platform-express';
 import {
   ApiBody,
   ApiConsumes,
@@ -114,7 +114,9 @@ export function ApiFile(
 ): MethodDecorator {
   const filesArray = _.castArray(files);
   const apiFileInterceptors = filesArray.map((file) =>
-    UseInterceptors(FileInterceptor(file.name)),
+    file.isArray
+      ? UseInterceptors(FilesInterceptor(file.name))
+      : UseInterceptors(FileInterceptor(file.name))
   );
 
   return applyDecorators(


### PR DESCRIPTION
The ApiFile decorator in swagger.schema.ts is not working when isArray is true in `IApiFile`.
It causes undefined or bad request.

Fix with `FilesInterceptor` instead of `FileInterceptor`.