### PR TITLE
fix error when use Unique Decorator

### DIFF
--- a/src/validators/unique.validator.ts
+++ b/src/validators/unique.validator.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { InjectConnection } from '@nestjs/typeorm';
+import { getRepository } from "typeorm"
 import type {
   ValidationArguments,
   ValidationOptions,
@@ -7,12 +7,10 @@ import type {
 } from 'class-validator';
 import { registerDecorator, ValidatorConstraint } from 'class-validator';
 import type { EntitySchema, FindConditions, ObjectType } from 'typeorm';
-import { Connection } from 'typeorm';
 
 @Injectable()
 @ValidatorConstraint({ name: 'unique', async: true })
 export class UniqueValidator implements ValidatorConstraintInterface {
-  constructor(@InjectConnection() private readonly connection: Connection) {}
 
   public async validate<E>(
     value: string,
@@ -21,7 +19,7 @@ export class UniqueValidator implements ValidatorConstraintInterface {
     const [entityClass, findCondition = args.property] = args.constraints;
 
     return (
-      (await this.connection.getRepository(entityClass).count({
+      (await getRepository(entityClass).count({
         where:
           typeof findCondition === 'function'
             ? findCondition(args)


### PR DESCRIPTION
export class RegisterUserDto {
  @ApiProperty({
    description: '用户邮件',
    uniqueItems: true,
  })
  @IsEmail()
  @Unique([UserEntity])
  email: string;

}


[Nest] 6168  - 2022/03/09 16:23:40   ERROR [ExceptionsHandler] Cannot read properties of undefined (reading 'getRepository')
TypeError: Cannot read properties of undefined (reading 'getRepository')
    at UniqueValidator.validate (E:\project\xplat-backfront\xplat-server\src\common\validator\unique.validator.ts:25:30)
    at E:\project\xplat-backfront\xplat-server\node_modules\src\validation\ValidationExecutor.ts:266:68
    at Array.forEach (<anonymous>)
    at E:\project\xplat-backfront\xplat-server\node_modules\src\validation\ValidationExecutor.ts:248:82
    at Array.forEach (<anonymous>)
    at ValidationExecutor.customValidations (E:\project\xplat-backfront\xplat-server\node_modules\src\validation\ValidationExecutor.ts:247:15)
    at ValidationExecutor.performValidations (E:\project\xplat-backfront\xplat-server\node_modules\src\validation\ValidationExecutor.ts:207:10)
    at E:\project\xplat-backfront\xplat-server\node_modules\src\validation\ValidationExecutor.ts:109:14
    at Array.forEach (<anonymous>)
    at ValidationExecutor.execute (E:\project\xplat-backfront\xplat-server\node_modules\src\validation\ValidationExecutor.ts:90:35)