### PR TITLE
refactor(dockerfile): replace node:lts with node:lts-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,33 +1,29 @@
-# Build stage
-FROM node:lts-alpine AS build
-WORKDIR /app
-
+FROM node:lts-alpine AS dist
 COPY package.json yarn.lock ./
+
 RUN yarn install
 
 COPY . ./
+
 RUN yarn build:prod
 
-# Production dependencies stage
 FROM node:lts-alpine AS node_modules
-WORKDIR /app
-
 COPY package.json yarn.lock ./
+
 RUN yarn install --prod
 
-# Final production image
 FROM node:lts-alpine
+
 ARG PORT=3000
 
-WORKDIR /app
+RUN mkdir -p /usr/src/app
 
-# Copy build output from build stage
-COPY --from=build /app/dist ./dist
-# Copy production node_modules from node_modules stage
-COPY --from=node_modules /app/node_modules ./node_modules
+WORKDIR /usr/src/app
 
-# Remove unnecessary files (e.g., package.json, yarn.lock, and other source files) from the final image
-COPY package.json yarn.lock ./
+COPY --from=dist dist /usr/src/app/dist
+COPY --from=node_modules node_modules /usr/src/app/node_modules
+
+COPY . /usr/src/app
 
 EXPOSE $PORT
 


### PR DESCRIPTION
This commit replaces the node:lts base image with the more lightweight node:lts-alpine in the Dockerfile. By using the Alpine-based image, the size of the resulting Docker image is significantly reduced, If there are any special needs or compatibility issues that require the use of node:lts, please fel free to reject this pull request :-)

<img width="876" alt="image" src="https://user-images.githubusercontent.com/49545778/230177373-68f15aab-3fa4-4c52-8e46-5ff43a0f1e23.png">

