### PR TITLE
docs: add gold sponsors (M One & HR Drone)

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,19 @@ This project includes a `docs` folder with more details on:
 1.  [Linting](https://narhakobyan.github.io/awesome-nest-boilerplate/linting.html)
 1.  [Code Generation](https://narhakobyan.github.io/awesome-nest-boilerplate/code-generation.html)
 
+## Gold Sponsors
+
+<table>
+  <tr>
+    <td align="center">
+      <a href="https://moneteam.com" target="_blank"><b>M One</b></a>
+    </td>
+    <td align="center">
+      <a href="https://hrdrone.am" target="_blank"><b>HR Drone</b></a>
+    </td>
+  </tr>
+</table>
+
 ## Community
 
 For help, discussion about best practices, or any other conversation that would benefit from being searchable:

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,3 +27,16 @@ features:
   - title: Biome + ESLint
     details: Fast, opinionated formatting and linting with pre-commit hooks via Husky.
 ---
+
+## Gold Sponsors
+
+<table>
+  <tr>
+    <td align="center">
+      <a href="https://moneteam.com" target="_blank"><b>M One</b></a>
+    </td>
+    <td align="center">
+      <a href="https://hrdrone.am" target="_blank"><b>HR Drone</b></a>
+    </td>
+  </tr>
+</table>


### PR DESCRIPTION
## Summary

- Adds a **Gold Sponsors** section to `README.md` (above the Community section)
- Adds the same section to `docs/index.md` (docs homepage, below the features block)
- Links to [M One](https://moneteam.com) and [HR Drone](https://hrdrone.am)

## Test plan

- [x] Verify sponsor links render correctly in the GitHub README preview
- [x] Verify links render correctly on the VitePress docs site

🤖 Generated with [Claude Code](https://claude.com/claude-code)