### PR TITLE
ci: optional nestjs-doctor scan on pull requests

### DIFF
--- a/.github/workflows/nestjs-doctor.yml
+++ b/.github/workflows/nestjs-doctor.yml
@@ -1,0 +1,17 @@
+name: NestJS Doctor
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  doctor:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # required to diff against the merge base
+      - uses: RoloBits/nestjs-doctor@v1


### PR DESCRIPTION
Disclosure: I maintain nestjs-doctor. Close this if it's not wanted, I won't reopen.

I ran the tool against this repo recently and your `@Auth()` decorator exposed a bug in our guard detection, which I fixed using this codebase to validate it. Since your code improved the tool, opening a PR here felt fair.

It adds one workflow that comments on pull requests with only what the change introduced. Advisory by default, it never fails a build unless you enable `blocking` or `min-score`.

One file, easy to revert. Docs at https://nestjs.doctor/docs/ci
