### PR TITLE
fix(post): guard the update and delete routes

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -10,6 +10,7 @@ import promisePlugin from 'eslint-plugin-promise';
 import simpleImportSort from 'eslint-plugin-simple-import-sort';
 import importPlugin from 'eslint-plugin-import';
 import unicornPlugin from 'eslint-plugin-unicorn';
+import nestjsSecurityPlugin from 'eslint-plugin-nestjs-security';
 import globals from 'globals';
 import tseslint from 'typescript-eslint';
 
@@ -461,6 +462,18 @@ export default tseslint.config(
         },
         tsconfigRootDir: import.meta.dirname,
       },
+    },
+  },
+  {
+    // One rule, not the recommended preset: `require-guards` reports a route
+    // handler that has no guard anywhere in its chain. It recognises the
+    // `@Auth()` wrapper in src/decorators/http.decorators.ts by resolving the
+    // decorator to the module it comes from, so wrapping UseGuards does not
+    // hide it.
+    files: ['src/**/*.controller.ts'],
+    plugins: { 'nestjs-security': nestjsSecurityPlugin },
+    rules: {
+      'nestjs-security/require-guards': 'error',
     },
   },
 );

--- a/package.json
+++ b/package.json
@@ -140,6 +140,7 @@
     "eslint-plugin-import": "^2.32.0",
     "eslint-plugin-import-helpers": "^2.0.1",
     "eslint-plugin-n": "^17.21.3",
+    "eslint-plugin-nestjs-security": "^2.0.2",
     "eslint-plugin-no-secrets": "^2.2.1",
     "eslint-plugin-prettier": "^5.5.4",
     "eslint-plugin-promise": "^7.2.1",

--- a/src/modules/post/post.controller.ts
+++ b/src/modules/post/post.controller.ts
@@ -80,6 +80,7 @@ export class PostController {
   }
 
   @Put(':id')
+  @Auth([RoleType.USER])
   @HttpCode(HttpStatus.ACCEPTED)
   @ApiUUIDParam('id')
   @ApiOperation({ summary: 'Update a post' })
@@ -92,6 +93,7 @@ export class PostController {
   }
 
   @Delete(':id')
+  @Auth([RoleType.USER])
   @HttpCode(HttpStatus.ACCEPTED)
   @ApiUUIDParam('id')
   @ApiOperation({ summary: 'Delete a post' })


### PR DESCRIPTION
Two commits: the fix, and the one lint rule that reports it. The second is separable — drop it if you'd rather not take the dependency.

### 1. `fix(post): guard the update and delete routes`

In `src/modules/post/post.controller.ts`, three of the five routes carry `@Auth`, and the two mutating ones do not:

| route | guard |
|---|---|
| `@Post()` | `@Auth([RoleType.USER])` |
| `@Get()` | `@Auth([RoleType.USER])` |
| `@Get(':id')` | `@Auth([])` |
| `@Put(':id')` | — |
| `@Delete(':id')` | — |

`@Auth` expands to `UseGuards(AuthGuard({ public: isPublicRoute }), RolesGuard)` in `src/decorators/http.decorators.ts`, so it is the access control here. As it stands, `PUT /posts/:id` and `DELETE /posts/:id` are reachable unauthenticated — any caller can edit or delete any post.

Given that creating and listing both require a user, this reads as an oversight rather than an intentional public endpoint.

```diff
   @Put(':id')
+  @Auth([RoleType.USER])
   @HttpCode(HttpStatus.ACCEPTED)
```

Same for `@Delete(':id')`. `[RoleType.USER]` matches `@Post()`.

**Out of scope:** this adds *authentication*, not ownership. `updatePost` and `deletePost` take only the id, so any authenticated user can still modify another user's post. Enforcing ownership means threading `@AuthUser()` into the service — a bigger change, and your call whether it belongs in a boilerplate.

### 2. `chore(lint): enable nestjs-security/require-guards on controllers`

A guard going missing is not the kind of thing review reliably catches — it is an *absence*, and it looked fine here for a while. This adds the single rule that reports it:

```js
{
  files: ['src/**/*.controller.ts'],
  plugins: { 'nestjs-security': nestjsSecurityPlugin },
  rules: { 'nestjs-security/require-guards': 'error' },
}
```

**One rule, not the recommended preset.** No other rule from the plugin is enabled, and nothing else in your config changes.

It understands this codebase's `@Auth()` wrapper: the rule resolves a decorator to the module it was imported from rather than matching names, so wrapping `UseGuards` in your own decorator does not hide the guard from it. It also stays quiet on routes that are public by design — auth entry points, health probes — and on projects with no authentication mechanism at all.

Verified against this repository:

- **before the fix:** 2 findings — `updatePost` (line 82), `deletePost` (line 94)
- **after the fix:** 0 findings across every `*.controller.ts`

So enabling it does not turn your lint red today; it fails only if a guard goes missing again.

Disclosure: I maintain that plugin. Happy to drop commit 2 and land only the fix — the fix stands on its own.