### PR TITLE
fix(post): require auth on the update and delete routes

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -4,6 +4,7 @@ import eslint from '@eslint/js';
 import stylisticPlugin from '@stylistic/eslint-plugin';
 import canonicalPlugin from 'eslint-plugin-canonical';
 import nPlugin from 'eslint-plugin-n';
+import nestjsSecurity from 'eslint-plugin-nestjs-security';
 import prettierPlugin from 'eslint-plugin-prettier/recommended';
 import sonarjsPlugin from 'eslint-plugin-sonarjs';
 import promisePlugin from 'eslint-plugin-promise';
@@ -439,6 +440,24 @@ export default tseslint.config(
       'use-isnan': 'error',
       'valid-typeof': 'off',
       'space-before-function-paren': 'off',
+    },
+  },
+  {
+    // One rule, not the plugin's recommended preset — nothing else it ships is
+    // enabled here. `require-guards` reports a route handler with no guard
+    // anywhere in its chain, which is the gap this PR's first commit closed on
+    // @Put(':id') and @Delete(':id').
+    //
+    // It resolves a decorator to the module it was imported from rather than
+    // matching on names, so the @Auth() wrapper in src/decorators/http.decorators.ts
+    // counts as a guard and does not have to be configured. Routes that are
+    // public by design — login, register, health — are recognised and stay
+    // silent, which is why auth.controller.ts and health-checker.controller.ts
+    // do not report.
+    files: ['src/**/*.controller.ts'],
+    plugins: { 'nestjs-security': nestjsSecurity },
+    rules: {
+      'nestjs-security/require-guards': 'error',
     },
   },
   {

--- a/package.json
+++ b/package.json
@@ -140,6 +140,7 @@
     "eslint-plugin-import": "^2.32.0",
     "eslint-plugin-import-helpers": "^2.0.1",
     "eslint-plugin-n": "^17.21.3",
+    "eslint-plugin-nestjs-security": "^2.1.0",
     "eslint-plugin-no-secrets": "^2.2.1",
     "eslint-plugin-prettier": "^5.5.4",
     "eslint-plugin-promise": "^7.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -282,6 +282,9 @@ importers:
       eslint-plugin-n:
         specifier: ^17.21.3
         version: 17.23.1(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)
+      eslint-plugin-nestjs-security:
+        specifier: ^2.1.0
+        version: 2.1.0(@nestjs/common@11.1.7(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/throttler@6.4.0(@nestjs/common@11.1.7(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.7)(reflect-metadata@0.2.2))(@typescript-eslint/utils@8.46.2(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3))(class-transformer@0.5.1)(class-validator@0.14.2)(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)
       eslint-plugin-no-secrets:
         specifier: ^2.2.1
         version: 2.2.1(eslint@9.38.0(jiti@2.6.1))
@@ -1828,6 +1831,22 @@ packages:
       '@types/node': '>=18'
     peerDependenciesMeta:
       '@types/node':
+        optional: true
+
+  '@interlace/eslint-devkit@1.9.0':
+    resolution: {integrity: sha512-fmdL13w3OZ0ilDhhF58dJP0GaWmi148JYM3LE4fXluk485n2XIo2/nNciM/KyWb1fLSJloAELpkZUYSOfsERWA==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      '@typescript-eslint/utils': ^7.0.0 || ^8.0.0
+      eslint: ^8.0.0 || ^9.0.0 || ^10.0.0
+      oxc-resolver: ^11.24.2
+      typescript: '>=4.8.4'
+    peerDependenciesMeta:
+      '@typescript-eslint/utils':
+        optional: true
+      oxc-resolver:
+        optional: true
+      typescript:
         optional: true
 
   '@ioredis/commands@1.5.0':
@@ -3684,6 +3703,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@unrs/resolver-binding-android-arm-eabi@1.11.1':
     resolution: {integrity: sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==}
@@ -4638,6 +4658,7 @@ packages:
   cron-parser@4.9.0:
     resolution: {integrity: sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q==}
     engines: {node: '>=12.0.0'}
+    deprecated: v4 is no longer maintained, upgrade to v5
 
   cron@4.4.0:
     resolution: {integrity: sha512-fkdfq+b+AHI4cKdhZlppHveI/mgz2qpiYxcm+t5E5TsxX7QrLS1VE0+7GENEk9z0EeGPcpSciGv6ez24duWhwQ==}
@@ -5036,6 +5057,25 @@ packages:
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: '>=8.23.0'
+
+  eslint-plugin-nestjs-security@2.1.0:
+    resolution: {integrity: sha512-jP5NcDmMAjEuflU6BNylfwPrGABo1E2lPHFtZ8/q8f9gPuEybzEVuLvrRObSouEQBm6nXF55RBoAnTjuqSXu7w==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      '@nestjs/common': ^9.0.0 || ^10.0.0 || ^11.0.0
+      '@nestjs/throttler': ^4.0.0 || ^5.0.0 || ^6.0.0
+      class-transformer: ^0.5.0
+      class-validator: ^0.14.0 || ^0.15.0
+      eslint: ^8.0.0 || ^9.0.0 || ^10.0.0
+    peerDependenciesMeta:
+      '@nestjs/common':
+        optional: true
+      '@nestjs/throttler':
+        optional: true
+      class-transformer:
+        optional: true
+      class-validator:
+        optional: true
 
   eslint-plugin-no-secrets@2.2.1:
     resolution: {integrity: sha512-/7BduEiFeINJ7mlc8iRmqp0sDw2a2lAFahig/RGppn7qf1dKhldXopUuv4M92kc4PX90dcxfKwKtYrW159cuhA==}
@@ -5513,16 +5553,18 @@ packages:
 
   glob@10.4.5:
     resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@11.0.3:
     resolution: {integrity: sha512-2Nim7dha1KVkaiF4q6Dj+ngPPMdfvLJEOpZk/jKiUAkqKebpGAWQXAq9z1xu9HKu5lWfqw/FASuccEjyznjPaA==}
     engines: {node: 20 || >=22}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   globals@14.0.0:
     resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
@@ -8175,10 +8217,12 @@ packages:
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   v8-compile-cache-lib@3.0.1:
@@ -10389,6 +10433,13 @@ snapshots:
   '@inquirer/type@3.0.9(@types/node@22.18.12)':
     optionalDependencies:
       '@types/node': 22.18.12
+
+  '@interlace/eslint-devkit@1.9.0(@typescript-eslint/utils@8.46.2(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)':
+    dependencies:
+      eslint: 9.38.0(jiti@2.6.1)
+    optionalDependencies:
+      '@typescript-eslint/utils': 8.46.2(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)
+      typescript: 5.9.3
 
   '@ioredis/commands@1.5.0': {}
 
@@ -14020,6 +14071,20 @@ snapshots:
       semver: 7.7.3
       ts-declaration-location: 1.0.7(typescript@5.9.3)
     transitivePeerDependencies:
+      - typescript
+
+  eslint-plugin-nestjs-security@2.1.0(@nestjs/common@11.1.7(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/throttler@6.4.0(@nestjs/common@11.1.7(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.7)(reflect-metadata@0.2.2))(@typescript-eslint/utils@8.46.2(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3))(class-transformer@0.5.1)(class-validator@0.14.2)(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3):
+    dependencies:
+      '@interlace/eslint-devkit': 1.9.0(@typescript-eslint/utils@8.46.2(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)
+      eslint: 9.38.0(jiti@2.6.1)
+    optionalDependencies:
+      '@nestjs/common': 11.1.7(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/throttler': 6.4.0(@nestjs/common@11.1.7(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.7)(reflect-metadata@0.2.2)
+      class-transformer: 0.5.1
+      class-validator: 0.14.2
+    transitivePeerDependencies:
+      - '@typescript-eslint/utils'
+      - oxc-resolver
       - typescript
 
   eslint-plugin-no-secrets@2.2.1(eslint@9.38.0(jiti@2.6.1)):

--- a/src/modules/post/post.controller.ts
+++ b/src/modules/post/post.controller.ts
@@ -80,6 +80,7 @@ export class PostController {
   }
 
   @Put(':id')
+  @Auth([RoleType.USER])
   @HttpCode(HttpStatus.ACCEPTED)
   @ApiUUIDParam('id')
   @ApiOperation({ summary: 'Update a post' })
@@ -92,6 +93,7 @@ export class PostController {
   }
 
   @Delete(':id')
+  @Auth([RoleType.USER])
   @HttpCode(HttpStatus.ACCEPTED)
   @ApiUUIDParam('id')
   @ApiOperation({ summary: 'Delete a post' })


### PR DESCRIPTION
Reading a post requires authentication. Destroying it does not.

Two changes: the fix, and the one lint rule that reports it. The second is separable — drop it if you'd rather not take the dependency.

## 1. `fix(post): require auth on the update and delete routes`

`PostController` guards three of its five routes and leaves two unguarded:

| route | guard |
|---|---|
| `@Post()` | `@Auth([RoleType.USER])` |
| `@Get()` | `@Auth([RoleType.USER])` |
| `@Get(':id')` | `@Auth([])` |
| `@Put(':id')` | — |
| `@Delete(':id')` | — |

`@Auth` expands to `UseGuards(AuthGuard({ public: isPublicRoute }), RolesGuard)` in `src/decorators/http.decorators.ts`, and there is no `APP_GUARD` or `useGlobalGuards` anywhere in the project — `main.ts` registers helmet, compression, morgan, filters, interceptors and pipes, but no guards. So those two routes have no authentication at all, not a weaker one.

Worth being precise about `@Auth([])` on `@Get(':id')`, since the empty array looks permissive but isn't. `AuthGuard()` builds `strategies = ['jwt']` and only appends `'public'` when `options.public` is set, so a JWT is still required; the empty array only reaches `RolesGuard`, which returns `true` when no roles are declared. `@Auth([])` means *"any authenticated user, no particular role"*. The genuinely-public spelling is `@Auth([], { public: true })`, backed by `PublicStrategy` in `src/modules/auth/public.strategy.ts` and registered in `auth.module.ts`. Neither of these two routes uses it.

Both handlers take only the id, so nothing fails on a missing user context, and `postService.updatePost` / `deletePost` look the row up by id and then `save` / `remove` with no ownership check. An anonymous caller who knows a post UUID can edit or delete anyone's post.

### Why this reads as an oversight rather than a choice

A policy can reasonably allow public reads with guarded writes. The reverse — a token required to *read* a post, nothing required to *destroy* it — isn't a policy anyone would design. `@Post()` requiring `@Auth([RoleType.USER])` to create while anyone can delete points the same way.

`7c848af` (which introduced these two routes) added `@Auth([])` to the new `@Get(':id')` in the same diff and omitted it here, so authentication was actively being applied in that edit.

Your genuinely public routes — `POST /auth/login`, `POST /auth/register`, `GET /health` — are unguarded for obvious reasons and are untouched.

```diff
   @Put(':id')
+  @Auth([RoleType.USER])
   @HttpCode(HttpStatus.ACCEPTED)
```

Same for `@Delete(':id')`. `[RoleType.USER]` matches `@Post()`. `Auth` and `RoleType` are already imported, so there are no import changes.

## 2. `chore(lint): enable nestjs-security/require-guards on controllers`

A guard going missing is an *absence*, which is not what review reliably catches — it looked fine here for three years. This adds the single rule that reports it:

```js
{
  files: ['src/**/*.controller.ts'],
  plugins: { 'nestjs-security': nestjsSecurity },
  rules: { 'nestjs-security/require-guards': 'error' },
}
```

**One rule, not the recommended preset.** Nothing else the plugin ships is enabled, and nothing else in `eslint.config.mjs` changes.

The plugin is listed in the [Lint section of `nestjs/awesome-nestjs`](https://github.com/nestjs/awesome-nestjs#lint) — the awesome list under the official NestJS organisation — alongside `eslint-plugin-nestjs`, `@darraghor/eslint-plugin-nestjs-typed` and `nestjs-doctor`. (Community-curated listing, not a core-team endorsement — but it is where this repo's readers would look for lint tooling.)

It understands this codebase without configuration: the rule resolves a decorator to the module it was imported from rather than matching on names, so your `@Auth()` wrapper counts as a guard even though it wraps `UseGuards` indirectly. Routes that are public by design — login, register, health — are recognised and stay silent, which is why `auth.controller.ts` and `health-checker.controller.ts` don't report.

### Verified against this repository, in a real install

- `pnpm install --frozen-lockfile` passes — the same command `.github/workflows/lint.yml` runs
- `npx eslint 'src/**/*.controller.ts'`: **2 errors before these changes, the same 2 after** — both pre-existing `@typescript-eslint/explicit-function-return-type`, one in a file this PR doesn't touch. This PR adds no new lint errors
- **`require-guards` contributes 0 findings** after commit 1, across every `*.controller.ts`
- Confirmed the rule is actually active rather than silently inert: removing the guard from `@Delete(':id')` makes it fire under your own config; restoring it goes clean
- The plugin resolves with no peer warnings against your stack (NestJS 11.1.7, ESLint 9.38.0, class-validator 0.14.2)

`pnpm-lock.yaml` is updated in its own commit — 66 lines for the new dependency and one refreshed deprecation notice, no other dependency moves — because `--frozen-lockfile` fails on a `package.json` the lockfile doesn't cover.

## Out of scope

This adds **authentication, not ownership**. After it, any authenticated user can still edit or delete another user's post, because the service never compares the post's author to the caller. Fixing that means threading `@AuthUser()` through to the service — a larger change, and arguably one an app author should make rather than the template.

If `post/` being a CRUD example means you'd rather leave guard placement to whoever builds on it, that's a fair call and I'll close this — but the read-vs-delete asymmetry seemed worth flagging either way, since the example is what people copy.

---

Assessed as [CWE-306](https://cwe.mitre.org/data/definitions/306.html) (Missing Authentication for Critical Function), CVSS 3.1 `AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N` = 7.5, if the module ships as-is.

Disclosure: I maintain `eslint-plugin-nestjs-security`. Happy to drop commits 2–3 and land only the fix — the fix stands on its own.